### PR TITLE
Add StartSpan and update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The `otel` package is a lightweight, thread-safe OpenTelemetry setup for distrib
 
 ## Features
 - **OpenTelemetry Tracing**: Initializes a `TracerProvider` with an OTLP gRPC exporter for production or a mock exporter for testing.
-- **Span Management**: Provides `GetTracer` for creating named tracers and spans.
+ - **Span Management**: Offers `GetTracer` and `StartSpan` for quick span creation without fetching a tracer first.
 - **Thread-Safety**: Uses `sync.RWMutex` for safe concurrent access to the `TracerProvider`.
 - **Integration**: Leverages `config` for settings and `logger` for trace-aware logging (`trace_id`, `span_id`).
 - **Propagation**: Supports W3C Trace Context and Baggage for distributed tracing.
@@ -37,8 +37,8 @@ go get github.com/T-Prohmpossadhorn/go-core/otel
 - `go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.29.0`
 - `go.opentelemetry.io/otel/exporters/stdout/stdouttrace@v1.29.0`
 - `go.opentelemetry.io/otel/sdk/trace@v1.29.0`
-- `github.com/T-Prohmpossadhorn/go-core/config`
-- `github.com/T-Prohmpossadhorn/go-core/logger`
+- `github.com/T-Prohmpossadhorn/go-core-config`
+- `github.com/T-Prohmpossadhorn/go-core-logger`
 - `github.com/spf13/viper@v1.18.2`
 
 Add to `go.mod`:
@@ -48,8 +48,8 @@ go get go.opentelemetry.io/otel@v1.29.0
 go get go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc@v1.29.0
 go get go.opentelemetry.io/otel/exporters/stdout/stdouttrace@v1.29.0
 go get go.opentelemetry.io/otel/sdk/trace@v1.29.0
-go get github.com/T-Prohmpossadhorn/go-core/config
-go get github.com/T-Prohmpossadhorn/go-core/logger
+go get github.com/T-Prohmpossadhorn/go-core-config
+go get github.com/T-Prohmpossadhorn/go-core-logger
 go get github.com/spf13/viper@v1.18.2
 ```
 
@@ -71,8 +71,8 @@ package main
 
 import (
     "context"
-    "github.com/T-Prohmpossadhorn/go-core/config"
-    "github.com/T-Prohmpossadhorn/go-core/otel"
+    config "github.com/T-Prohmpossadhorn/go-core-config"
+    "github.com/T-Prohmpossadhorn/go-core-otel"
 )
 
 func main() {
@@ -88,9 +88,8 @@ func main() {
     }
     defer otel.Shutdown(context.Background())
 
-    // Create a tracer and start a span
-    tracer := otel.GetTracer("example-service")
-    ctx, span := tracer.Start(context.Background(), "process-request")
+    // Start a span using the convenience helper
+    ctx, span := otel.StartSpan(context.Background(), "example-service", "process-request")
     defer span.End()
 
     // Simulate work
@@ -108,9 +107,9 @@ package main
 
 import (
     "context"
-    "github.com/T-Prohmpossadhorn/go-core/config"
-    "github.com/T-Prohmpossadhorn/go-core/logger"
-    "github.com/T-Prohmpossadhorn/go-core/otel"
+    config "github.com/T-Prohmpossadhorn/go-core-config"
+    logger "github.com/T-Prohmpossadhorn/go-core-logger"
+    "github.com/T-Prohmpossadhorn/go-core-otel"
 )
 
 func main() {
@@ -136,9 +135,8 @@ func main() {
     }
     defer otel.Shutdown(context.Background())
 
-    // Create a tracer and start a span
-    tracer := otel.GetTracer("user-service")
-    ctx, span := tracer.Start(context.Background(), "handle-user-request")
+    // Start a span without fetching a tracer first
+    ctx, span := otel.StartSpan(context.Background(), "user-service", "handle-user-request")
     defer span.End()
 
     // Log with trace context
@@ -164,9 +162,9 @@ package main
 
 import (
     "context"
-    "github.com/T-Prohmpossadhorn/go-core/config"
-    "github.com/T-Prohmpossadhorn/go-core/logger"
-    "github.com/T-Prohmpossadhorn/go-core/otel"
+    config "github.com/T-Prohmpossadhorn/go-core-config"
+    logger "github.com/T-Prohmpossadhorn/go-core-logger"
+    "github.com/T-Prohmpossadhorn/go-core-otel"
     "go.opentelemetry.io/otel/baggage"
     "go.opentelemetry.io/otel/propagation"
 )
@@ -198,9 +196,8 @@ func main() {
     }
     defer otel.Shutdown(context.Background())
 
-    // Create a tracer and start a span
-    tracer := otel.GetTracer("order-service")
-    ctx, span := tracer.Start(context.Background(), "process-order")
+    // Start a span for the order-service
+    ctx, span := otel.StartSpan(context.Background(), "order-service", "process-order")
     defer span.End()
 
     // Add baggage
@@ -219,8 +216,7 @@ func main() {
 
     // Simulate downstream service call with extracted context
     downstreamCtx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.MapCarrier(carrier))
-    downstreamTracer := otel.GetTracer("payment-service")
-    downstreamCtx, downstreamSpan := downstreamTracer.Start(downstreamCtx, "process-payment")
+    downstreamCtx, downstreamSpan := otel.StartSpan(downstreamCtx, "payment-service", "process-payment")
     defer downstreamSpan.End()
 
     logger.InfoContext(downstreamCtx, "Processing payment",

--- a/examples/main.go
+++ b/examples/main.go
@@ -2,6 +2,10 @@ package main
 
 import (
 	"context"
+
+	config "github.com/T-Prohmpossadhorn/go-core-config"
+	logger "github.com/T-Prohmpossadhorn/go-core-logger"
+	"github.com/T-Prohmpossadhorn/go-core-otel"
 )
 
 func main() {
@@ -23,9 +27,8 @@ func main() {
 	}
 	defer otel.Shutdown(context.Background())
 
-	// Create tracer and span
-	tracer := otel.GetTracer("example")
-	ctx, span := tracer.Start(context.Background(), "example-span")
+	// Start span without explicitly fetching a tracer
+	ctx, span := otel.StartSpan(context.Background(), "example", "example-span")
 	defer span.End()
 
 	// Log with span context

--- a/otel.go
+++ b/otel.go
@@ -9,6 +9,9 @@ import (
 	"sync"
 	"time"
 
+	config "github.com/T-Prohmpossadhorn/go-core-config"
+	"github.com/T-Prohmpossadhorn/go-core-logger"
+
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
@@ -177,4 +180,11 @@ func GetTracer(name string) oteltrace.Tracer {
 	}
 	logger.Debug("Returning tracer", logger.String("name", name), logger.Any("tracerProvider", tracerProvider))
 	return tracerProvider.Tracer(name)
+}
+
+// StartSpan starts a span with the given tracer name and span name without the
+// caller needing to fetch the tracer first.
+func StartSpan(ctx context.Context, tracerName, spanName string, opts ...oteltrace.SpanStartOption) (context.Context, oteltrace.Span) {
+	tracer := GetTracer(tracerName)
+	return tracer.Start(ctx, spanName, opts...)
 }

--- a/otel_test.go
+++ b/otel_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	config "github.com/T-Prohmpossadhorn/go-core-config"
+	logger "github.com/T-Prohmpossadhorn/go-core-logger"
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/baggage"


### PR DESCRIPTION
## Summary
- switch to `go-core-config` and `go-core-logger` packages
- provide `StartSpan` helper for easy span creation
- update examples and docs to use the new packages and helper

## Testing
- `go vet ./...`
- `go test ./...`
